### PR TITLE
update mirrors.kernel.org link in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
 ENV GNUARMEMB_TOOLCHAIN_PATH=/workdir/gcc-arm-none-eabi-7-2018-q2-update
 # Device Tree Compile 1.4.7
 RUN mkdir -p /data/device-tree-compiler/ && \
-    wget -q 'http://mirrors.kernel.org/ubuntu/pool/main/d/device-tree-compiler/device-tree-compiler_1.4.7-1_amd64.deb' \
+    wget -q 'http://mirrors.kernel.org/ubuntu/pool/main/d/device-tree-compiler/device-tree-compiler_1.4.7-3_amd64.deb' \
         -O /data/device-tree-compiler/device-tree-compiler_1.4.7-1_amd64.deb && \
     dpkg -i /data/device-tree-compiler/device-tree-compiler_1.4.7-1_amd64.deb
 # Latest PIP


### PR DESCRIPTION
Old link was missing on mirrors.kernel.org site