### PR TITLE
Disable debug logs

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -43,13 +43,31 @@ jobs:
           docker run --rm -v ${PWD}:/workdir/ncs/firmware bifravst-firmware-docker /bin/bash -c 'cd ncs/firmware; west build -p always -b nrf9160_pca10090ns'
           cp -v build/zephyr/merged.hex ${GITHUB_WORKSPACE}/cat-tracker-nrf9160_pca10090ns.hex
           cp -v build/zephyr/app_update.bin ${GITHUB_WORKSPACE}/cat-tracker-nrf9160_pca10090ns-app_update.bin
-      - name: "Build Thingy:91 for NB-IoT"
+
+      - name: Publish 9160 DK NB-IoT firmware as artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: 9160 DK NB-IoT firmware
+          path: |
+            cat-tracker-nrf9160_pca10090ns.hex
+            cat-tracker-nrf9160_pca10090ns-app_update.bin
+
+      - name: Build Thingy:91 for NB-IoT
         run: |
           echo "CONFIG_CAT_TRACKER_APP_VERSION=\"${NEXT_VERSION}-thingy91-nbiot\"" >> prj_thingy91_nrf9160ns.conf
           cat prj_thingy91_nrf9160ns.conf
           docker run --rm -v ${PWD}:/workdir/ncs/firmware bifravst-firmware-docker /bin/bash -c 'cd ncs/firmware; west build -p always -b thingy91_nrf9160ns'
           cp -v build/zephyr/merged.hex ${GITHUB_WORKSPACE}/cat-tracker-thingy91_nrf9160ns.hex
           cp -v build/zephyr/app_update.bin ${GITHUB_WORKSPACE}/cat-tracker-thingy91_nrf9160ns-app_update.bin
+
+      - name: Publish Thingy:91 NB-IoT firmware as artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Thingy 91 NB-IoT firmware
+          path: |
+            cat-tracker-thingy91_nrf9160ns.hex
+            cat-tracker-thingy91_nrf9160ns-app_update.bin
+
       - name: Build 9160 DK for LTE-m
         run: |
           echo "CONFIG_CAT_TRACKER_APP_VERSION=\"${NEXT_VERSION}-9160dk-ltem\"" >> prj.conf
@@ -59,7 +77,16 @@ jobs:
           docker run --rm -v ${PWD}:/workdir/ncs/firmware bifravst-firmware-docker /bin/bash -c 'cd ncs/firmware; west build -p always -b nrf9160_pca10090ns'
           cp -v build/zephyr/merged.hex ${GITHUB_WORKSPACE}/cat-tracker-nrf9160_pca10090ns-ltem.hex
           cp -v build/zephyr/app_update.bin ${GITHUB_WORKSPACE}/cat-tracker-nrf9160_pca10090ns-ltem-app_update.bin
-      - name: "Build Thingy:91 for LTE-m"
+
+      - name: Publish 9160 DK LTE-m firmware as artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: 9160 DK LTE-m firmware
+          path: |
+            cat-tracker-nrf9160_pca10090ns-ltem.hex
+            cat-tracker-nrf9160_pca10090ns-ltem-app_update.bin
+
+      - name: Build Thingy:91 for LTE-m
         run: |
           echo "CONFIG_CAT_TRACKER_APP_VERSION=\"${NEXT_VERSION}-thingy91-ltem\"" >> prj_thingy91_nrf9160ns.conf
           sed -i s/CONFIG_LTE_NETWORK_MODE_NBIOT_GPS=y/CONFIG_LTE_NETWORK_MODE_LTE_M_GPS=y/ prj_thingy91_nrf9160ns.conf
@@ -68,6 +95,14 @@ jobs:
           docker run --rm -v ${PWD}:/workdir/ncs/firmware bifravst-firmware-docker /bin/bash -c 'cd ncs/firmware; west build -p always -b thingy91_nrf9160ns'
           cp -v build/zephyr/merged.hex ${GITHUB_WORKSPACE}/cat-tracker-thingy91_nrf9160ns-ltem.hex
           cp -v build/zephyr/app_update.bin ${GITHUB_WORKSPACE}/cat-tracker-thingy91_nrf9160ns-ltem-app_update.bin
+
+      - name: Publish Thingy:91 LTE-m firmware as artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Thingy 91 LTE-m firmware
+          path: |
+            cat-tracker-thingy91_nrf9160ns-ltem.hex
+            cat-tracker-thingy91_nrf9160ns-ltem-app_update.bin
 
       - name: Semantic release
         continue-on-error: true

--- a/prj.conf
+++ b/prj.conf
@@ -22,6 +22,9 @@ CONFIG_LOG_IMMEDIATE=y
 # 3 INFO, maximal level set to LOG_LEVEL_INFO
 # 4 DEBUG, maximal level set to LOG_LEVEL_DBG
 CONFIG_LOG_MAX_LEVEL=3
+# This enables debug messages from the cat tracker module in case
+# CONFIG_LOG_MAX_LEVEL is set to 4
+CONFIG_CAT_TRACKER_LOG_LEVEL_DBG=y
 
 # Buttons and LEDs
 CONFIG_DK_LIBRARY=y

--- a/prj.conf
+++ b/prj.conf
@@ -11,6 +11,17 @@ CONFIG_ASSERT=y
 CONFIG_REBOOT=y
 CONFIG_LOG=y
 CONFIG_LOG_IMMEDIATE=y
+# Forces a maximal log level for all modules.
+# Modules saturates their specified level if it is greater than this option,
+# otherwise they use the level specified by this option instead of their default
+# or whatever was manually set. Levels are:
+#
+# 0 OFF, logging is turned off
+# 1 ERROR, maximal level set to LOG_LEVEL_ERR
+# 2 WARNING, maximal level set to LOG_LEVEL_WRN
+# 3 INFO, maximal level set to LOG_LEVEL_INFO
+# 4 DEBUG, maximal level set to LOG_LEVEL_DBG
+CONFIG_LOG_MAX_LEVEL=3
 
 # Buttons and LEDs
 CONFIG_DK_LIBRARY=y

--- a/prj_thingy91_nrf9160ns.conf
+++ b/prj_thingy91_nrf9160ns.conf
@@ -22,6 +22,9 @@ CONFIG_LOG_IMMEDIATE=y
 # 3 INFO, maximal level set to LOG_LEVEL_INFO
 # 4 DEBUG, maximal level set to LOG_LEVEL_DBG
 CONFIG_LOG_MAX_LEVEL=3
+# This enables debug messages from the cat tracker module in case
+# CONFIG_LOG_MAX_LEVEL is set to 4
+CONFIG_CAT_TRACKER_LOG_LEVEL_DBG=y
 
 # Buttons and LEDs
 CONFIG_DK_LIBRARY=y

--- a/prj_thingy91_nrf9160ns.conf
+++ b/prj_thingy91_nrf9160ns.conf
@@ -11,6 +11,17 @@ CONFIG_ASSERT=y
 CONFIG_REBOOT=y
 CONFIG_LOG=y
 CONFIG_LOG_IMMEDIATE=y
+# Forces a maximal log level for all modules.
+# Modules saturates their specified level if it is greater than this option,
+# otherwise they use the level specified by this option instead of their default
+# or whatever was manually set. Levels are:
+#
+# 0 OFF, logging is turned off
+# 1 ERROR, maximal level set to LOG_LEVEL_ERR
+# 2 WARNING, maximal level set to LOG_LEVEL_WRN
+# 3 INFO, maximal level set to LOG_LEVEL_INFO
+# 4 DEBUG, maximal level set to LOG_LEVEL_DBG
+CONFIG_LOG_MAX_LEVEL=3
 
 # Buttons and LEDs
 CONFIG_DK_LIBRARY=y

--- a/src/cloud_codec/cloud_codec.c
+++ b/src/cloud_codec/cloud_codec.c
@@ -104,7 +104,7 @@ int cloud_codec_decode_response(char *input, struct cloud_data_cfg *data)
 		goto exit;
 	}
 
-	printk("Decoded message: %s\n", string);
+	LOG_DBG("Decoded message: %s", log_strdup(string));
 
 	group_obj = json_object_decode(root_obj, "cfg");
 	if (group_obj != NULL) {
@@ -182,7 +182,7 @@ static int cloud_codec_static_modem_data_add(cJSON *parent,
 	static const char gps_string[] = " GPS";
 
 	if (!data->queued) {
-		LOG_INF("Head of modem buffer not indexing a queued entry");
+		LOG_DBG("Head of modem buffer not indexing a queued entry");
 		goto exit;
 	}
 
@@ -234,7 +234,7 @@ static int cloud_codec_dynamic_modem_data_add(cJSON *parent,
 	long mccmnc;
 
 	if (!data->queued) {
-		LOG_INF("Head of modem buffer not indexing a queued entry");
+		LOG_DBG("Head of modem buffer not indexing a queued entry");
 		goto exit;
 	}
 
@@ -290,7 +290,7 @@ static int cloud_codec_sensor_data_add(cJSON *parent,
 	int err = 0;
 
 	if (!data->queued) {
-		LOG_INF("Head of sensor buffer not indexing a queued entry");
+		LOG_DBG("Head of sensor buffer not indexing a queued entry");
 		goto exit;
 	}
 
@@ -335,7 +335,7 @@ static int cloud_codec_gps_data_add(cJSON *parent, struct cloud_data_gps *data,
 	int err = 0;
 
 	if (!data->queued) {
-		LOG_INF("Head of gps buffer not indexing a queued entry");
+		LOG_DBG("Head of gps buffer not indexing a queued entry");
 		goto exit;
 	}
 
@@ -390,7 +390,7 @@ static int cloud_codec_accel_data_add(cJSON *parent,
 	int err = 0;
 
 	if (!data->queued) {
-		LOG_INF("Head of accel buffer not indexing a queued entry");
+		LOG_DBG("Head of accel buffer not indexing a queued entry");
 		goto exit;
 	}
 
@@ -435,7 +435,7 @@ static int cloud_codec_ui_data_add(cJSON *parent, struct cloud_data_ui *data,
 	int err = 0;
 
 	if (!data->queued) {
-		LOG_INF("Head of UI buffer not indexing a queued entry");
+		LOG_DBG("Head of UI buffer not indexing a queued entry");
 		goto exit;
 	}
 
@@ -475,7 +475,7 @@ static int cloud_codec_bat_data_add(cJSON *parent,
 	int err = 0;
 
 	if (!data->queued) {
-		LOG_INF("Head of battery buffer not indexing a queued entry");
+		LOG_DBG("Head of battery buffer not indexing a queued entry");
 		goto exit;
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -221,7 +221,7 @@ static void battery_buffer_populate(void)
 	bat_buf[head_bat_buf].bat_ts = k_uptime_get();
 	bat_buf[head_bat_buf].queued = true;
 
-	LOG_INF("Entry: %d of %d in battery buffer filled", head_bat_buf,
+	LOG_DBG("Entry: %d of %d in battery buffer filled", head_bat_buf,
 		CONFIG_BAT_BUFFER_MAX - 1);
 }
 
@@ -242,7 +242,7 @@ static void gps_buffer_populate(struct gps_pvt *gps_data)
 	gps_buf[head_gps_buf].gps_ts = k_uptime_get();
 	gps_buf[head_gps_buf].queued = true;
 
-	LOG_INF("Entry: %d of %d in GPS buffer filled", head_gps_buf,
+	LOG_DBG("Entry: %d of %d in GPS buffer filled", head_gps_buf,
 		CONFIG_GPS_BUFFER_MAX - 1);
 }
 
@@ -335,7 +335,7 @@ populate_buffer:
 		accel_buf[head_accel_buf].ts = k_uptime_get();
 		accel_buf[head_accel_buf].queued = true;
 
-		LOG_INF("Entry: %d of %d in accelerometer buffer filled",
+		LOG_DBG("Entry: %d of %d in accelerometer buffer filled",
 			head_accel_buf, CONFIG_ACCEL_BUFFER_MAX - 1);
 
 		buf_entry_try_again_timeout = k_uptime_get();
@@ -389,7 +389,7 @@ static int modem_buffer_populate(void)
 	modem_buf[head_modem_buf].mod_ts_static = k_uptime_get();
 	modem_buf[head_modem_buf].queued = true;
 
-	LOG_INF("Entry: %d of %d in modem buffer filled", head_modem_buf,
+	LOG_DBG("Entry: %d of %d in modem buffer filled", head_modem_buf,
 		CONFIG_MODEM_BUFFER_MAX - 1);
 
 	return 0;
@@ -422,7 +422,7 @@ static int sensors_buffer_populate(void)
 	sensors_buf[head_sensor_buf].env_ts = k_uptime_get();
 	sensors_buf[head_sensor_buf].queued = true;
 
-	LOG_INF("Entry: %d of %d in sensor buffer filled", head_sensor_buf,
+	LOG_DBG("Entry: %d of %d in sensor buffer filled", head_sensor_buf,
 		CONFIG_SENSOR_BUFFER_MAX - 1);
 
 	return 0;
@@ -441,7 +441,7 @@ static void ui_buffer_populate(int btn_number)
 	ui_buf[head_ui_buf].btn_ts = k_uptime_get();
 	ui_buf[head_ui_buf].queued = true;
 
-	LOG_INF("Entry: %d of %d in UI buffer filled", head_ui_buf,
+	LOG_DBG("Entry: %d of %d in UI buffer filled", head_ui_buf,
 		CONFIG_UI_BUFFER_MAX - 1);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -1346,7 +1346,6 @@ void main(void)
 	k_delayed_work_submit(&mov_timeout_work, K_SECONDS(cfg.movt));
 
 	while (true) {
-
 		/*Check current device mode*/
 		if (!cfg.act) {
 			LOG_INF("Device in PASSIVE mode");

--- a/src/main.c
+++ b/src/main.c
@@ -1077,7 +1077,7 @@ static void modem_rsrp_handler(char rsrp_value)
 
 	rsrp_value_latest = rsrp_value;
 
-	LOG_INF("Incoming RSRP status message, RSRP value is %d",
+	LOG_DBG("Incoming RSRP status message, RSRP value is %d",
 		rsrp_value_latest);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -572,7 +572,7 @@ static void device_config_send(void)
 
 	err = cloud_codec_encode_cfg_data(&msg, &cfg);
 	if (err == -EAGAIN) {
-		LOG_INF("No change in device configuration");
+		LOG_DBG("No change in device configuration");
 		return;
 	} else if (err) {
 		LOG_ERR("Device configuration not encoded, error: %d", err);
@@ -1034,10 +1034,10 @@ void cloud_event_handler(const struct cloud_backend *const backend,
 		sys_reboot(0);
 		break;
 	case CLOUD_EVT_DATA_SENT:
-		LOG_INF("CLOUD_EVT_DATA_SENT");
+		LOG_DBG("CLOUD_EVT_DATA_SENT");
 		break;
 	case CLOUD_EVT_DATA_RECEIVED:
-		LOG_INF("CLOUD_EVT_DATA_RECEIVED");
+		LOG_DBG("CLOUD_EVT_DATA_RECEIVED");
 		err = cloud_codec_decode_response(evt->data.msg.buf, &cfg);
 		if (err) {
 			LOG_ERR("Could not decode response %d", err);
@@ -1048,10 +1048,10 @@ void cloud_event_handler(const struct cloud_backend *const backend,
 		k_delayed_work_submit(&device_config_send_work, K_NO_WAIT);
 		break;
 	case CLOUD_EVT_PAIR_REQUEST:
-		LOG_INF("CLOUD_EVT_PAIR_REQUEST");
+		LOG_DBG("CLOUD_EVT_PAIR_REQUEST");
 		break;
 	case CLOUD_EVT_PAIR_DONE:
-		LOG_INF("CLOUD_EVT_PAIR_DONE");
+		LOG_DBG("CLOUD_EVT_PAIR_DONE");
 		break;
 	default:
 		LOG_ERR("Unknown cloud event type: %d", evt->type);


### PR DESCRIPTION
This changes the default log level to info to reduce noise and updates some less interesting log levels to debug.

It also includes and update the the CI pipeline which publishes the firmware files as artifacts so they can be tried out directly.