### PR TITLE
check expected modem firmware

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -101,9 +101,9 @@ endmenu # Watchdog
 endmenu
 
 menu "Zephyr Kernel"
-source "$ZEPHYR_BASE/Kconfig.zephyr"
+source "Kconfig.zephyr"
 endmenu
 
 module = CAT_TRACKER
 module-str = Cat Tracker
-source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+source "subsys/logging/Kconfig.template.log_config"

--- a/Kconfig
+++ b/Kconfig
@@ -22,6 +22,10 @@ config CAT_TRACKER_APP_VERSION
 	string "The version of the cat tracker firmware"
 	default "0.0.0-development"
 
+config EXPECTED_MODEM_FIRMWARE_VERSION
+	string "The expected modem firmware version"
+	default "0.0.0-development"
+
 endmenu # Firmware versioning
 
 menu "Cloud"

--- a/src/main.c
+++ b/src/main.c
@@ -352,6 +352,30 @@ populate_buffer:
 }
 #endif
 
+/* Produce a warning if modem firmware version is unexpected. */
+static void check_modem_fw_version(void)
+{
+	static bool modem_fw_version_checked;
+
+	if (modem_fw_version_checked) {
+		return;
+	}
+	if (strcmp(modem_param.device.modem_fw.value_string,
+		   CONFIG_EXPECTED_MODEM_FIRMWARE_VERSION) != 0) {
+		LOG_WRN("Unsupported modem firmware version: %s",
+			log_strdup(modem_param.device.modem_fw.value_string));
+		LOG_WRN("Expected firmware version: %s",
+			CONFIG_EXPECTED_MODEM_FIRMWARE_VERSION);
+		LOG_WRN("You can change the expected version through the");
+		LOG_WRN("EXPECTED_MODEM_FIRMWARE_VERSION setting.");
+		LOG_WRN("Please upgrade: http://bit.ly/nrf9160-mfw-update");
+	} else {
+		LOG_INF("Board is running expected modem firmware version: %s",
+			log_strdup(modem_param.device.modem_fw.value_string));
+	}
+	modem_fw_version_checked = true;
+}
+
 static int modem_buffer_populate(void)
 {
 	int err;
@@ -362,6 +386,8 @@ static int modem_buffer_populate(void)
 		LOG_ERR("modem_info_params_get, error: %d", err);
 		return err;
 	}
+
+	check_modem_fw_version();
 
 	/* Go to start of buffer if end is reached. */
 	head_modem_buf += 1;

--- a/src/main.c
+++ b/src/main.c
@@ -1363,7 +1363,6 @@ void main(void)
 	}
 
 	while (true) {
-
 		/*Check current device mode*/
 		if (!cfg.act) {
 			LOG_INF("Device in PASSIVE mode");

--- a/src/ui/Kconfig
+++ b/src/ui/Kconfig
@@ -47,4 +47,4 @@ endmenu
 
 module = UI
 module-str = User Interface
-source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+source "subsys/logging/Kconfig.template.log_config"


### PR DESCRIPTION
This adds a one-time check which compares the modem firmware
to an expected version configured in 
`CONFIG_EXPECTED_MODEM_FIRMWARE_VERSION`.

Closes #70 