### PR TITLE
feat: make watchdog config use seconds

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -96,9 +96,9 @@ endmenu # Cloud codec
 
 menu "Watchdog"
 
-config CAT_TRACKER_WATCHDOG_TIMEOUT_MSEC
-	int "Watchdog timeout in milliseconds"
-	default 60000
+config CAT_TRACKER_WATCHDOG_TIMEOUT_SEC
+	int "Watchdog timeout in seconds"
+	default 60
 
 endmenu # Watchdog
 

--- a/src/main.c
+++ b/src/main.c
@@ -1354,7 +1354,8 @@ void main(void)
 	LOG_INF(" The cat tracker has started");
 	LOG_INF(" Version:     %s", log_strdup(CONFIG_CAT_TRACKER_APP_VERSION));
 	LOG_INF(" IMEI:        %s", log_strdup(client_id_buf));
-	LOG_INF(" Endpoint:    %s", log_strdup(CONFIG_AWS_IOT_BROKER_HOST_NAME));
+	LOG_INF(" Endpoint:    %s",
+		log_strdup(CONFIG_AWS_IOT_BROKER_HOST_NAME));
 	LOG_INF("********************************************");
 
 	err = ui_init();

--- a/src/watchdog/watchdog.c
+++ b/src/watchdog/watchdog.c
@@ -12,7 +12,9 @@
 LOG_MODULE_REGISTER(watchdog, CONFIG_CAT_TRACKER_LOG_LEVEL);
 
 #define WDT_FEED_WORKER_DELAY_MS                                               \
-	((CONFIG_CAT_TRACKER_WATCHDOG_TIMEOUT_MSEC) / 2)
+	((CONFIG_CAT_TRACKER_WATCHDOG_TIMEOUT_SEC * 1000) / 2)
+#define CAT_TRACKER_WATCHDOG_TIMEOUT_MSEC                                      \
+	(CONFIG_CAT_TRACKER_WATCHDOG_TIMEOUT_SEC * 1000)
 
 struct wdt_data_storage {
 	struct device *wdt_drv;
@@ -42,7 +44,7 @@ static int watchdog_timeout_install(struct wdt_data_storage *data)
 		.window =
 			{
 				.min = 0,
-				.max = CONFIG_CAT_TRACKER_WATCHDOG_TIMEOUT_MSEC,
+				.max = CAT_TRACKER_WATCHDOG_TIMEOUT_MSEC,
 			},
 		.callback = NULL,
 		.flags = WDT_FLAG_RESET_SOC
@@ -58,8 +60,8 @@ static int watchdog_timeout_install(struct wdt_data_storage *data)
 		return -EFAULT;
 	}
 
-	LOG_INF("Watchdog timeout installed. Timeout: %d",
-		CONFIG_CAT_TRACKER_WATCHDOG_TIMEOUT_MSEC);
+	LOG_INF("Watchdog timeout installed. Timeout: %ds",
+		CONFIG_CAT_TRACKER_WATCHDOG_TIMEOUT_SEC);
 	return 0;
 }
 


### PR DESCRIPTION
Watchdog timeouts should be in the range of seconds or minutes
so this makes the configuration value use seconds

BREAKING CHANGE: The CAT_TRACKER_WATCHDOG_TIMEOUT_MSEC config is replaced