### PR TITLE
test(e2e): add markers for test runner

### DIFF
--- a/ci/schedule.ts
+++ b/ci/schedule.ts
@@ -244,10 +244,9 @@ const e2e = async () => {
 			timeoutInMinutes,
 			abortOn: [`aws_fota: Error (-7) when trying to start firmware download`],
 			endOn: [
-				`Version:     ${appVersion}-upgraded`,
 				// Wait for the shadow update
-				`"appV": "${appVersion}-upgraded"`,
-				'MQTT_EVT_SUBACK',
+				`<TEST:ENCODE_APPV> ${appVersion}-upgraded`,
+				'<TEST:DATA_SEND> OK',
 			],
 		})
 

--- a/src/cloud_codec/cloud_codec.c
+++ b/src/cloud_codec/cloud_codec.c
@@ -588,6 +588,7 @@ int cloud_codec_encode_data(struct cloud_codec_data *output,
 			err += cloud_codec_static_modem_data_add(rep_obj,
 								 modem_buf);
 				initial_encode = true;
+			LOG_DBG("<TEST:ENCODE_APPV> %s", modem_buf->appv);
 		}
 
 		err += cloud_codec_dynamic_modem_data_add(rep_obj, modem_buf,

--- a/src/main.c
+++ b/src/main.c
@@ -646,6 +646,7 @@ static void data_send(void)
 		LOG_ERR("Cloud send failed, err: %d", err);
 		return;
 	}
+	LOG_DBG("<TEST:DATA_SEND> OK");
 }
 
 static void buffered_data_send(void)


### PR DESCRIPTION
This adds log messages which the test runner can use
to detect when the end state of the test run has been
reached.